### PR TITLE
リンクページの幅が伸びていたので修正。余計なホバー動作を消去

### DIFF
--- a/tos/main.css
+++ b/tos/main.css
@@ -4,7 +4,7 @@
   font-family: Arial, sans-serif;
   background-color: #383737;
   white-space:nowrap;
-  /* max-width: 770px; */
+  max-width: 770px; 
   color:#C6C3C9;
 }
 
@@ -76,9 +76,7 @@
   transition: transform 0.5s ease;
 }
 
-.link-block:hover .link-text {
-  transform: translateY(-100%);
-}
+
 
 .footer {
   background-color: #212121;


### PR DESCRIPTION
## 変更場所
tos main.html/css

## 変更内容
・PCで閲覧した時、コンテナが異様に横に伸びていたので横幅の最大値を設定しました。
・マウスクリック時にリンク先の説明をするタグが上へ推移する処理が含まれていましたが、視認性が悪いので除去しました。

